### PR TITLE
fix: ignore deactivated shapes in closed validation

### DIFF
--- a/lib/Shape.js
+++ b/lib/Shape.js
@@ -1,4 +1,5 @@
 import once from 'lodash/once.js'
+import { fromRdf } from 'rdf-literal'
 import * as ns from './namespaces.js'
 import parsePath from './parsePath.js'
 import ShapeValidator from './ShapeValidator.js'
@@ -9,11 +10,20 @@ class Shape {
     this.ptr = ptr
     this.validator = validator
 
+    this._deactivated = once(() => {
+      const deactivatedTerm = this.ptr.out([ns.sh.deactivated]).term
+
+      return deactivatedTerm && fromRdf(deactivatedTerm)
+    })
     this._message = once(() => this.ptr.out([ns.sh.message]).terms)
     this._path = once(() => parsePath(this.ptr.out([ns.sh.path])))
     this._severity = once(() => this.ptr.out([ns.sh.severity]).term)
     this._shapeValidator = once(() => new ShapeValidator(this))
     this._targetResolver = once(() => new TargetResolver(this.ptr))
+  }
+
+  get deactivated () {
+    return this._deactivated()
   }
 
   get isPropertyShape () {

--- a/lib/validations.js
+++ b/lib/validations.js
@@ -1,5 +1,4 @@
 import TermMap from '@rdfjs/term-map'
-import { fromRdf } from 'rdf-literal'
 import * as ns from './namespaces.js'
 import { compileMaxCount, compileMinCount } from './validations/cardinality.js'
 import { compileAnd, compileNot, compileOr, compileXone } from './validations/logical.js'
@@ -18,10 +17,9 @@ class Registry {
 
   compile (shape) {
     const coverage = shape.validator.options.coverage
-    const deactivatedTerm = shape.ptr.out([ns.sh.deactivated]).term
 
     // ignore deactivated shape
-    if (deactivatedTerm && fromRdf(deactivatedTerm)) {
+    if (shape.deactivated) {
       return []
     }
 

--- a/lib/validations/other.js
+++ b/lib/validations/other.js
@@ -10,7 +10,7 @@ function compileClosedNode (shape) {
   }
 
   const propertyShapes = shape.ptr.out([ns.sh.property]).map(ptr => shape.validator.shape(ptr))
-  const properties = new TermSet(propertyShapes.map(shape => shape.path[0].predicates[0]))
+  const properties = new TermSet(propertyShapes.filter(shape => !shape.deactivated).map(shape => shape.path[0].predicates[0]))
   const ignoredProperties = new TermSet([...(shape.ptr.out([ns.sh.ignoredProperties]).list() || [])].map(item => item.term))
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shacl-engine",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A fast RDF/JS SHACL engine",
   "type": "module",
   "main": "index.js",

--- a/test/assets/custom/deactivated-closed.ttl
+++ b/test/assets/custom/deactivated-closed.ttl
@@ -1,0 +1,49 @@
+@prefix ex: <http://example.org/>.
+@prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix shn: <https://schemas.link/shacl-next#>.
+@prefix sht: <http://www.w3.org/ns/shacl-test#>.
+
+<> a mf:Manifest;
+  mf:entries (<deactivated-closed>).
+
+<deactivated-closed> a sht:Validate;
+  rdfs:label "Test of closed shape with deactivated property shape";
+  mf:action [
+      sht:dataGraph <>;
+      sht:shapesGraph <>
+    ];
+  mf:result [ a sh:ValidationReport;
+      sh:conforms true;
+      sh:result [ a sh:ValidationResult;
+          sh:focusNode ex:data;
+          sh:resultSeverity shn:Debug;
+          sh:sourceConstraintComponent sh:ClosedConstraintComponent;
+          sh:sourceShape ex:RootShape
+        ], [ a sh:ValidationResult;
+          sh:focusNode ex:data;
+          sh:resultPath ex:property1;
+          sh:resultSeverity shn:Trace;
+          sh:sourceConstraintComponent shn:TraversalConstraintComponent;
+          sh:sourceShape ex:Property1Shape;
+          sh:value 1
+        ]
+    ].
+
+ex:data
+  ex:property1 1.
+
+ex:Property1Shape a sh:PropertyShape;
+  sh:path ex:property1.
+
+ex:Property2Shape a sh:PropertyShape;
+  sh:deactivated true.
+
+ex:RootShape a sh:NodeShape;
+  sh:closed true;
+  sh:property
+    ex:Property1Shape,
+    ex:Property2Shape;
+  sh:targetNode ex:data.

--- a/test/assets/custom/manifest.ttl
+++ b/test/assets/custom/manifest.ttl
@@ -5,6 +5,7 @@
   rdfs:label "Custom tests";
   mf:include
     <and-multi-list.ttl>,
+    <deactivated-closed.ttl>,
     <or-multi-list.ttl>,
     <qualifiedValueShape.ttl>,
     <xone-multi-list.ttl>.


### PR DESCRIPTION
Only add shapes to closed validation if they are not deactivated.