### PR TITLE
chore: update CI workflow and bump c8 to 12.0.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,17 +4,16 @@ on:
   - push
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node:
-          - '18'
-          - '20'
           - '22'
-          - '23'
+          - '24'
+          - '26'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
@@ -26,7 +25,7 @@ jobs:
           parallel: true
   finally:
     needs: test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: coverallsapp/github-action@v2
         with:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@rdfjs/normalize": "^2.0.4",
     "@rdfjs/parser-n3": "^2.2.0",
     "@rdfjs/traverser": "^0.1.4",
-    "c8": "^11.0.0",
+    "c8": "^12.0.0",
     "mocha": "^11.7.6",
     "rdf-test": "^0.1.1",
     "rdf-utils-fs": "^3.0.1",


### PR DESCRIPTION
Drop Node 18/20/23 from the test matrix, add 24/26, bump actions/checkout and actions/setup-node to v7, and switch to ubuntu-latest. Also bumps the c8 devDependency from 11.0.0 to 12.0.0.